### PR TITLE
Give proper credits for Icon Pack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I would be very happy**
 Features:
 
 - Dark and light theme and many material accents!;
-- Icon packs support (credits to Evervolv Rom);
+- Icon packs support (credits to Evervolv Rom / Lawnchair / @deletescape);
 - Per-app icons (credits to aospa, just revised);
 - Custom labels;
 - Hidden app


### PR DESCRIPTION
Evervolv's Icon Pack support is mostly based on a commit picked from Lawnchair, properly give credits.